### PR TITLE
Add light theme XML using Material Components for base app styling

### DIFF
--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.AirGuard" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <!-- Primary branding color. -->
+        <item name="colorPrimary">#1976D2</item>
+        <item name="colorPrimaryVariant">#1565C0</item>
+        <item name="colorOnPrimary">#FFFFFF</item>
+
+        <!-- Secondary color. -->
+        <item name="colorSecondary">#03DAC6</item>
+        <item name="colorSecondaryVariant">#018786</item>
+        <item name="colorOnSecondary">#000000</item>
+
+        <!-- Surface and background -->
+        <item name="colorSurface">#FFFFFF</item>
+        <item name="colorOnSurface">#000000</item>
+        <item name="colorBackground">#F5F5F5</item>
+        <item name="colorOnBackground">#000000</item>
+
+        <!-- Error colors -->
+        <item name="colorError">#B00020</item>
+        <item name="colorOnError">#FFFFFF</item>
+
+        <!-- Status bar, navigation bar -->
+        <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
+        <item name="android:navigationBarColor" tools:targetApi="l">?attr/colorPrimary</item>
+    </style>
+</resources>


### PR DESCRIPTION
Introduces a new ```themes.xml``` file under ```res/values/```, defining the light mode Material Design theme for AirGuard. The theme includes custom color definitions for primary, secondary, background, surface, and error states, as well as system bar configurations.